### PR TITLE
reproduction for issue with turbopack

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -136,7 +136,7 @@ let nextConfig = {
   experimental: {
     appDir: true,
     // https://beta.nextjs.org/docs/configuring/typescript#statically-typed-links
-    typedRoutes: true,
+    // typedRoutes: true,
     mdxRs: true,
     // https://nextjs.org/docs/advanced-features/output-file-tracing#caveats
     // outputFileTracingRoot: workspaceRoot,


### PR DESCRIPTION
Reproduction for https://github.com/vercel/next.js/issues/42651

- PNPM 8.4.0 
- monorepo 
- node.js v18.16.0
- auto-peers-deps false -> https://github.com/belgattitude/artist/blob/main/.npmrc

Clone: https://github.com/belgattitude/artist/pull/4

```bash
corepack enable
pnpm install
cd apps/web
pnpm dev --turbo
```

On client

![image](https://user-images.githubusercontent.com/259798/236313495-b6378f94-dcb6-4ec9-9fef-0294ab89b73f.png)

On server

![image](https://user-images.githubusercontent.com/259798/236313632-f683c2e6-0a18-4868-867d-2458afa7c60d.png)
