### PR TITLE
chore(deps): updated react three drei to 9.77.7

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,7 +30,7 @@
     "@httpx/exception": "1.8.1",
     "@next/mdx": "13.4.8-canary.11",
     "@nextvalid/zod-request": "0.4.0",
-    "@react-three/drei": "9.77.6",
+    "@react-three/drei": "9.77.7",
     "@react-three/fiber": "8.13.4",
     "@soluble/cache-interop": "0.12.7",
     "@soluble/cache-ioredis": "0.13.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
         specifier: 0.4.0
         version: 0.4.0(@types/node@20.3.2)(next@13.4.8-canary.11)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)
       '@react-three/drei':
-        specifier: 9.77.6
-        version: 9.77.6(@react-three/fiber@8.13.4)(@types/three@0.152.1)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
+        specifier: 9.77.7
+        version: 9.77.7(@react-three/fiber@8.13.4)(@types/three@0.152.1)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
       '@react-three/fiber':
         specifier: 8.13.4
         version: 8.13.4(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
@@ -4897,8 +4897,8 @@ packages:
     resolution: {integrity: sha512-POu8Mk0hIU3lRXB3bGIGe4VHIwwDsQyoD1F394OK7STTiX9w4dG3cTLljjYswkQN+hDSHRrj4O36kuVa7KPU8Q==}
     dev: false
 
-  /@react-three/drei@9.77.6(@react-three/fiber@8.13.4)(@types/three@0.152.1)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0):
-    resolution: {integrity: sha512-A5LUUniz8mvtfd51zc6YaMY5Ypur75cZhm4v3iSotb8GbR40UlQ0bTxLWhN//93hUZXysIUBkSPOKsIqUSPnVQ==}
+  /@react-three/drei@9.77.7(@react-three/fiber@8.13.4)(@types/three@0.152.1)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0):
+    resolution: {integrity: sha512-eR2DvlZMba2lypjAkp7pt/c86sHwWUBZds3iCGZP4+uNJcb+l3wixln0yGvjM8GHcJXt0P0+h43YCEOMb4Dfmw==}
     peerDependencies:
       '@react-three/fiber': '>=8.0'
       react: '>=18.0'


### PR DESCRIPTION
Reproduction for https://github.com/pmndrs/drei/issues/1544

```bash
pnpm i
cd apps/web
pnpm build-fast
```

with `pnpm dev` -> http://localhost:3000/video

```
- error ../../node_modules/.pnpm/@react-three+drei@9.77.7_@react-three+fiber@8.13.4_@types+three@0.152.1_react-dom@18.2.0_react@18.2.0_three@0.154.0/node_modules/@react-three/drei/index.cjs.js (1:8648) @ eval
- error TypeError: a is not a function
    at __webpack_require__ (/home/sebastien/github/artist/apps/web/.next/server/webpack-runtime.js:33:43)
    at eval (./src/app/video/page.tsx:7:75)
    at (sc_client)/./src/app/video/page.tsx (/home/sebastien/github/artist/apps/web/.next/server/app/video/page.js:3722:1)
    at __webpack_require__ (/home/sebastien/github/artist/apps/web/.next/server/webpack-runtime.js:33:43)

```

