### PR TITLE
Nextjs 13.4.9 - issue with eslint-plugin-react-hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,6 @@
   "dependencies": {
     "cross-env": "7.0.3"
   },
-  "resolutions?": {
-    "eslint-plugin-react-hooks": "Nextjs 13.4.9 has a dependency on eslint-plugin-react-hooks 5-canary"
-  },
-  "resolutions": {
-    "eslint-plugin-react-hooks": "4.6.0"
-  },
   "devDependencies": {
     "@changesets/changelog-github": "0.4.8",
     "@belgattitude/eslint-config-bases": "1.35.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-overrides:
-  eslint-plugin-react-hooks: 4.6.0
-
 importers:
 
   .:
@@ -9865,7 +9862,7 @@ packages:
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.60.1)(eslint-import-resolver-typescript@3.5.5)(eslint@8.44.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.44.0)
       eslint-plugin-react: 7.32.2(eslint@8.44.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.44.0)
+      eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.44.0)
       typescript: 5.1.6
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
@@ -10121,6 +10118,15 @@ packages:
 
   /eslint-plugin-react-hooks@4.6.0(eslint@8.44.0):
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    dependencies:
+      eslint: 8.44.0
+    dev: true
+
+  /eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705(eslint@8.44.0):
+    resolution: {integrity: sha512-AZYbMo/NW9chdL7vk6HQzQhT+PvTAEVqWk9ziruUoW2kAOcN5qNyelv70e0F1VNQAbvutOC9oc+xfWycI9FxDw==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0


### PR DESCRIPTION
Upstream issue  https://github.com/vercel/next.js/issues/52365  Related to https://github.com/vercel/next.js/pull/52275

```bash
git clone -b nextjs-reprod-eslint-react-hooks --single-branch https://github.com/belgattitude/artist.git
cd artist
pnpm install
cd apps/web
pnpm lint
```

![image](https://github.com/belgattitude/artist/assets/259798/4d2c5644-7454-404e-bda2-d9ac7d1bbb7d)


See https://github.com/belgattitude/artist/actions/runs/5480794201/jobs/9984365681?pr=7